### PR TITLE
Fix license name in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Luiz Felipe Machado Barboza"
   },
-  "license": "BDS-3-Clause",
+  "license": "BSD-3-Clause",
   "type": "module",
   "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
The license visible at https://www.npmjs.com/package/splaytree-ts appears to be wrongly spelled. This PR just makes sure it gets spelled correctly.